### PR TITLE
Remove absolute imports

### DIFF
--- a/src/commands/check/parseFile.test.ts
+++ b/src/commands/check/parseFile.test.ts
@@ -1,6 +1,6 @@
 import { SimpleGit } from 'simple-git';
 
-import { parseMetadata } from 'utils/metadata';
+import { parseMetadata } from '../../utils/metadata';
 import {
   createCommits,
   createDocumentationFile,
@@ -9,7 +9,7 @@ import {
   deleteRepo,
   getRepoPath,
   wait,
-} from 'utils/testRepo';
+} from '../../utils/testRepo';
 
 import parseFile, { getDocumentationLastUpdate } from './parseFile';
 

--- a/src/commands/update/index.test.ts
+++ b/src/commands/update/index.test.ts
@@ -7,7 +7,7 @@ import {
   createRepo,
   deleteRepo,
   getRepoPath,
-} from 'utils/testRepo';
+} from '../../utils/testRepo';
 
 import updateFile from '.';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,12 @@
 import { dim, green, red, underline, yellow } from 'colorette';
 import yargs from 'yargs/yargs';
 
-import { ParseFileOptions } from 'commands/check/types';
-import { CreateDocumentationOptions } from 'commands/create/types';
-import { UpdateFileOptions } from 'commands/update/types';
-
 import checkFile from './commands/check';
+import { ParseFileOptions } from './commands/check/types';
 import createDocumentation from './commands/create';
+import { CreateDocumentationOptions } from './commands/create/types';
 import updateFile from './commands/update';
+import { UpdateFileOptions } from './commands/update/types';
 
 const checkFiles = async (
   files: string[],

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,12 +1,7 @@
 import { SimpleGit } from 'simple-git';
 
-import getLastCommitHash from 'utils/git';
-import {
-  createCommits,
-  createRepo,
-  deleteRepo,
-  getRepoPath,
-} from 'utils/testRepo';
+import getLastCommitHash from './git';
+import { createCommits, createRepo, deleteRepo, getRepoPath } from './testRepo';
 
 describe('getLastCommitHash', () => {
   let git: SimpleGit;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "rootDir": "src",
-    "outDir": "dist",
-    "baseUrl": "src",
+    "outDir": "dist"
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
Reason: Typescript isn't able to transform them during compilation to relative imports. In the future, it may be done with https://github.com/LeDDGroup/typescript-transform-paths